### PR TITLE
Update: Schema blog(added redirectionURL)🔥

### DIFF
--- a/prisma/migrations/20250111060915_redirection_url_to_blog/migration.sql
+++ b/prisma/migrations/20250111060915_redirection_url_to_blog/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "blogs" ADD COLUMN     "redirectionUrl" TEXT DEFAULT '';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,6 +133,7 @@ model blogs {
   Canonical_Tag    String?
   Meta_description String?
   isPublished      Boolean          @default(false)
+  redirectionUrl   String?          @default("")
 }
 
 model blogs_comments {


### PR DESCRIPTION
This pull request includes changes to add a new column for redirection URLs to the `blogs` table in the database schema and corresponding updates to the Prisma schema file.

Database schema changes:

* [`prisma/migrations/20250111060915_redirection_url_to_blog/migration.sql`](diffhunk://#diff-dde6fbccd03cdd8191ea246976f3106c0f307d4ddd2ade302cdbeb7e9dd62b76R1-R2): Added a new column `redirectionUrl` to the `blogs` table with a default value of an empty string.

Prisma schema updates:

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR136): Added a new optional field `redirectionUrl` to the `blogs` model with a default value of an empty string.